### PR TITLE
Support lod groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.1.0] - 2025.09.17
+
+### Added
+
+- Support for LOD Group Component (only if `Use Geometry` is set to `Render Meshes`)
+    - First LOD is used (`LOD 0`)
+    - All renderers from `LOD 0` are included when baking
+
 ## [1.0.0] - 2025.09.13
 
 ### Added
@@ -10,3 +18,4 @@
 
 [Unreleased]: https://github.com/lajawi/unity-navmesh-better-bake/blob/main
 [1.0.0]: https://github.com/lajawi/unity-navmesh-better-bake/releases/tag/v1.0.0
+[1.1.0]: https://github.com/lajawi/unity-navmesh-better-bake/compare/v1.0.0...v1.1.0

--- a/Editor/BetterNavMeshSurfaceEditor.cs
+++ b/Editor/BetterNavMeshSurfaceEditor.cs
@@ -154,7 +154,7 @@ namespace Lajawi
         {
             if (lodGroup.GetLODs().Length <= 0)
             {
-                Debug.Log($"{treePrefab.name} has an {nameof(LODGroup)} but no LOD levels set up.", treePrefab);
+                Debug.Log($"{treePrefab.name} has an {nameof(LODGroup)} but no LODs set up.", treePrefab);
                 return false;
             }
 
@@ -164,7 +164,7 @@ namespace Lajawi
             {
                 if (!renderer)
                 {
-                    Debug.LogWarning($"The {nameof(LODGroup)} LOD level 0 has an empty or missing item.", lodGroup);
+                    Debug.LogWarning($"The {nameof(LODGroup)} LOD 0 has an empty or missing item.", lodGroup);
                     continue;
                 }
                 if (!renderer.gameObject.TryGetComponent(out MeshFilter lodMeshFilter))
@@ -178,7 +178,7 @@ namespace Lajawi
             }
             if (lodGroup.GetLODs()[0].renderers.Length <= 0)
             {
-                Debug.LogWarning($"{treePrefab.name} has an {nameof(LODGroup)} component, but no {nameof(Renderer)}'s on LOD level 0.", treePrefab);
+                Debug.LogWarning($"{treePrefab.name} has an {nameof(LODGroup)} component, but no {nameof(Renderer)}'s on LOD 0.", treePrefab);
                 return false;
             }
             if (lodParent.transform.childCount <= 0)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ A Unity package that enhances the [NavMesh Surface](https://docs.unity3d.com/Pac
 > [!IMPORTANT]
 > You need Unity's [AI Navigation](https://docs.unity3d.com/Packages/com.unity.ai.navigation@2.0/manual/index.html) package. When you install this package, it should depend on it and install it automatically for you.
 
-Install the package according to the [installation instructions]. Once installed, you can use the extra buttons from the *NavMesh Surface* to use this package to bake.
+Install the package according to the [installation instructions](#installation). Once installed, you can use the extra buttons from the *NavMesh Surface* to use this package to bake.
 
 ![Screenshot of the NavMesh Surface component, with the extra buttons.](./Documentation~/images/navmesh-surface-component-with-package.png)
 
 ### What this package currently does
 
 - Make real instances of terrain trees for baking (they get removed after baking). These trees support the following components:
+  - LOD Groups, only used when *Use Geometry* is set to *Render Meshes*, takes precedence to just a Mesh Renderer and Mesh Filter on the root object of a tree
   - Mesh Renderer and Mesh Filter, only used when *Use Geometry* is set to *Render Meshes*, [#Problems that may not be obvious](#mesh-renderer--mesh-filter)
   - Colliders of any type, can be multiple, mix and matched, only used when *Use Geometry* is set to *Physics Colliders*
   - NavMesh Modifier

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.lajawi.betternavmeshbake",
-  "version": "1.0.0",
+  "version": "1.1.0",
 
   "displayName": "Better NavMesh Bake",
   "description": "Adds a little convenience for baking NavMesh Surfaces.",


### PR DESCRIPTION
Now supports the LOD group component when baking with `Use Geometry` set to `Render Meshes`.

- First LOD is used (LOD 0)
- All renderers of LOD 0 get utilised, with their correct child position and rotation

Closes #1 